### PR TITLE
Switch AppVeyor to organization account

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Download badge](https://cranlogs.r-pkg.org/badges/LPWC)](https://cran.r-project.org/package=LPWC)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![codecov](https://codecov.io/gh/gitter-lab/LPWC/branch/master/graph/badge.svg)](https://codecov.io/gh/gitter-lab/LPWC)
-[![Build status](https://ci.appveyor.com/api/projects/status/9xtm9s42awiir55r?svg=true)](https://ci.appveyor.com/project/agitter/lpwc)
+[![Build status](https://ci.appveyor.com/api/projects/status/851q74xh2ue87tid?svg=true)](https://ci.appveyor.com/project/gitter-lab/lpwc)
 
 **Authors**: Thevaa Chandereng and Anthony Gitter
 


### PR DESCRIPTION
Closes #20.  Created and linked an organization account with the instructions here: https://www.appveyor.com/docs/team-setup/#setting-up-appveyor-account-for-github-organization